### PR TITLE
refactor: :recycle: this is the intended method of using home manager modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,5 +37,9 @@
       namespace = "me";
       package-namespace = "me";
       src = ./.;
+
+      homes.users."jack@mollerbot".modules = with inputs; [
+        nix-index-database.hmModules.nix-index # Comma
+      ];
     };
 }

--- a/homes/x86_64-linux/jack@mollerbot/default.nix
+++ b/homes/x86_64-linux/jack@mollerbot/default.nix
@@ -1,9 +1,5 @@
 { inputs, pkgs, config, osConfig, ... }: {
   home.stateVersion = "23.05";
-  imports = [
-    inputs.nix-index-database.hmModules.nix-index
-    { programs.nix-index-database.comma.enable = true; }
-  ];
   home.packages = [
     pkgs.obsidian
     pkgs.songrec
@@ -35,6 +31,7 @@
       };
       extraConfig = "$env.config.show_banner = false;";
     };
+    nix-index-database.comma.enable = true;
     bun.enable = true;
     obs-studio.enable = true;
     vscode.enable = true;


### PR DESCRIPTION
I just noticed this when adding it to my configuration doesn't really need to be changed it's just the intended method of doing it with Snowfall lib